### PR TITLE
Make footer mobile responsive to new design

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 ## Install
 
 To run this project or storybook, you first must install node modules.
-`
+```
     yarn install
-`
+```
 
 ## Start development server
 

--- a/assets/global.css
+++ b/assets/global.css
@@ -71,8 +71,20 @@
     font-stretch: normal;
 }
 
+html {
+    font-family: "Graphik LCG Web", Arial, sans-serif;
+}
+
 a {
+    color: var(--S1000);
+}
+
+header a {
     color: var(--S1000)!important;
+}
+
+footer a {
+    color: var(--S20)!important;
 }
 
 pre {

--- a/components/ButtonLink/component.tsx
+++ b/components/ButtonLink/component.tsx
@@ -10,7 +10,6 @@ const StyledLink = styled.a`
 	color: ${(props: { hierarchy: Hierarchy }) =>
 		props.hierarchy === 'primary' ? colours.Y80 : colours.S1000}!important;
 	display: inline-block;
-	font-family: 'Graphik LCG Web';
 	font-size: 16px;
 	font-weight: 500;
 	line-height: 24px;

--- a/components/Card/component.tsx
+++ b/components/Card/component.tsx
@@ -15,8 +15,6 @@ const StyledContainer = styled.a`
 	margin: 24px 0px;
 	text-decoration: none;
 
-	font-family: 'Graphik LCG Web';
-
 	:hover {
 		border: 1px solid ${colours.primaryTurqoise};
 		text-decoration: none;

--- a/components/Footer/FooterLinkList/__snapshots__/test.spec.tsx.snap
+++ b/components/Footer/FooterLinkList/__snapshots__/test.spec.tsx.snap
@@ -6,12 +6,18 @@ exports[`FooterLinkList component component matches snapshot 2`] = `
 <styled.div>
   <styled.div
     key="0"
+    onClick={[Function]}
   >
     <styled.p>
       Solution
+      <styled.div>
+        <Chevron />
+      </styled.div>
     </styled.p>
     <styled.div>
-      <styled.div>
+      <styled.div
+        isDisplayed={false}
+      >
         <styled.a
           href="/solutions"
           key="0"
@@ -69,7 +75,7 @@ exports[`FooterLinkList component component matches snapshot 2`] = `
         </styled.a>
       </styled.div>
       <styled.div
-        className="solutions-second-col"
+        isDisplayed={false}
       >
         <styled.a
           href="/solutions/fraud"
@@ -120,11 +126,17 @@ exports[`FooterLinkList component component matches snapshot 2`] = `
   </styled.div>
   <styled.div
     key="1"
+    onClick={[Function]}
   >
     <styled.p>
       Company
+      <styled.div>
+        <Chevron />
+      </styled.div>
     </styled.p>
-    <styled.div>
+    <styled.div
+      isDisplayed={false}
+    >
       <styled.a
         href="/about-us"
         key="0"
@@ -184,11 +196,17 @@ exports[`FooterLinkList component component matches snapshot 2`] = `
   </styled.div>
   <styled.div
     key="2"
+    onClick={[Function]}
   >
     <styled.p>
       Insights
+      <styled.div>
+        <Chevron />
+      </styled.div>
     </styled.p>
-    <styled.div>
+    <styled.div
+      isDisplayed={false}
+    >
       <styled.a
         href="/blog"
         key="0"
@@ -215,11 +233,17 @@ exports[`FooterLinkList component component matches snapshot 2`] = `
   </styled.div>
   <styled.div
     key="3"
+    onClick={[Function]}
   >
     <styled.p>
       Resources
+      <styled.div>
+        <Chevron />
+      </styled.div>
     </styled.p>
-    <styled.div>
+    <styled.div
+      isDisplayed={false}
+    >
       <styled.a
         href="https://docs.checkout.com/"
         key="0"

--- a/components/Footer/FooterLinkList/component.tsx
+++ b/components/Footer/FooterLinkList/component.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Chevron } from '../../svg';
 import {
 	Container,
 	SolutionsLinksContainer,
@@ -8,50 +9,75 @@ import {
 	FooterTitle,
 	FooterLink,
 	LinkText,
+	StyledIcon,
 } from './styles';
 
-const FooterLinkList = ({ links = [] }) => (
-	<Container>
-		{links?.map((link, i) => {
-			if (i === 0) {
-				return (
-					<SolutionsLinksContainer key={i}>
-						<FooterTitle>{link.primary.title[0].text}</FooterTitle>
-						<ColMainWrapper>
-							<ColWrapper>
-								{link.items.slice(0, link.items.length / 2 + 1).map((item, i) => (
-									<FooterLink href={item.link_href[0].text} labelHere={item.link_name[0].text === 'Careers'} key={i}>
-										<LinkText> {item.link_name[0].text} </LinkText>
-									</FooterLink>
-								))}
-							</ColWrapper>
+const FooterLinkList = ({ links = [] }) => {
+	const [showSolutions, setSolutions] = useState<boolean>(false);
+	const [showCompany, setCompany] = useState<boolean>(false);
+	const [showInsights, setInsights] = useState<boolean>(false);
+	const [showResources, setResources] = useState<boolean>(false);
 
-							<ColWrapper className="solutions-second-col">
-								{link.items.slice(link.items.length / 2 + 1, link.items.length).map((item, i) => (
+	const setFuncs = [
+		() => setCompany(!showCompany),
+		() => setInsights(!showInsights),
+		() => setResources(!showResources),
+	];
+	const showStatements = [showCompany, showInsights, showResources];
+
+	return (
+		<Container>
+			{links?.map((link, i) => {
+				if (i === 0) {
+					return (
+						<SolutionsLinksContainer key={i} onClick={() => setSolutions(!showSolutions)}>
+							<FooterTitle>
+								{link.primary.title[0].text}
+								<StyledIcon>
+									<Chevron />
+								</StyledIcon>
+							</FooterTitle>
+							<ColMainWrapper>
+								<ColWrapper isDisplayed={showSolutions}>
+									{link.items.slice(0, link.items.length / 2 + 1).map((item, i) => (
+										<FooterLink href={item.link_href[0].text} labelHere={item.link_name[0].text === 'Careers'} key={i}>
+											<LinkText> {item.link_name[0].text} </LinkText>
+										</FooterLink>
+									))}
+								</ColWrapper>
+
+								<ColWrapper isDisplayed={showSolutions}>
+									{link.items.slice(link.items.length / 2 + 1, link.items.length).map((item, i) => (
+										<FooterLink href={item.link_href[0].text} labelHere={item.link_name[0].text === 'Careers'} key={i}>
+											<LinkText> {item.link_name[0].text} </LinkText>
+										</FooterLink>
+									))}
+								</ColWrapper>
+							</ColMainWrapper>
+						</SolutionsLinksContainer>
+					);
+				} else {
+					return (
+						<LinksContainer key={i} onClick={setFuncs[i - 1]}>
+							<FooterTitle>
+								{link.primary.title[0].text}
+								<StyledIcon>
+									<Chevron />
+								</StyledIcon>
+							</FooterTitle>
+							<ColWrapper isDisplayed={showStatements[i - 1]}>
+								{link.items.map((item, i) => (
 									<FooterLink href={item.link_href[0].text} labelHere={item.link_name[0].text === 'Careers'} key={i}>
 										<LinkText> {item.link_name[0].text} </LinkText>
 									</FooterLink>
 								))}
 							</ColWrapper>
-						</ColMainWrapper>
-					</SolutionsLinksContainer>
-				);
-			} else {
-				return (
-					<LinksContainer key={i}>
-						<FooterTitle>{link.primary.title[0].text}</FooterTitle>
-						<ColWrapper>
-							{link.items.map((item, i) => (
-								<FooterLink href={item.link_href[0].text} labelHere={item.link_name[0].text === 'Careers'} key={i}>
-									<LinkText> {item.link_name[0].text} </LinkText>
-								</FooterLink>
-							))}
-						</ColWrapper>
-					</LinksContainer>
-				);
-			}
-		})}
-	</Container>
-);
+						</LinksContainer>
+					);
+				}
+			})}
+		</Container>
+	);
+};
 
 export default FooterLinkList;

--- a/components/Footer/FooterLinkList/styles.tsx
+++ b/components/Footer/FooterLinkList/styles.tsx
@@ -5,30 +5,35 @@ export const Container = styled.div`
 	display: flex;
 	justify-content: space-between;
 
-	${device.toMobileXL} {
+	${device.toTablet} {
 		flex-direction: column;
 	}
 `;
 
 export const SolutionsLinksContainer = styled.div`
 	width: 32%;
-	margin-top: 40px;
+	margin-top: 20px;
 
 	@media only screen and (min-width: 768px) and (max-width: 1080px) {
+		margin-top: 40px;
+		padding: 0 0 20px 0;
 		width: 36%;
 	}
 
 	${device.toTablet} {
+		border-bottom: 1px solid ${colours.S05};
+		margin-top: 40px;
+		padding: 0 0 20px 0;
 		width: auto;
-		padding: 0;
 	}
 `;
 
 export const LinksContainer = styled.div`
-	margin-top: 40px;
+	margin-top: 20px;
 
 	${device.toTablet} {
-		padding: 0;
+		border-bottom: 1px solid ${colours.S05};
+		padding: 0 0 20px 0;
 	}
 `;
 
@@ -47,6 +52,8 @@ export const ColWrapper = styled.div`
 	flex-direction: column;
 
 	${device.toTablet} {
+		display: ${(props: { isDisplayed: boolean }) => (props.isDisplayed ? 'flex' : 'none')};
+		transition: all 0.5s;
 		&.solutions-second-col {
 			margin-top: 0;
 		}
@@ -54,7 +61,6 @@ export const ColWrapper = styled.div`
 `;
 
 export const FooterTitle = styled.p`
-	font-family: 'Graphik LCG Web', 'sans-serif';
 	font-style: normal;
 	font-weight: 600;
 	font-size: 12px;
@@ -62,11 +68,12 @@ export const FooterTitle = styled.p`
 	letter-spacing: 0.11em;
 	text-transform: uppercase;
 	color: white;
+	display: flex;
+	justify-content: space-between;
 	-webkit-font-smoothing: antialiased;
 `;
 
 export const FooterLink = styled.a`
-	font-family: 'Graphik LCG Web', 'sans-serif';
 	font-style: normal;
 	font-weight: normal;
 	font-size: 14px;
@@ -83,7 +90,6 @@ export const FooterLink = styled.a`
 		props.labelHere
 			? `&::after {
         content:  "WE'RE HIRING";
-        font-family: 'Graphik LCG Web', 'sans-serif';
         font-style: normal;
         font-weight: 500;
         font-size: 10px;
@@ -112,4 +118,13 @@ export const LinkText = styled.div`
 	display: inline;
 	padding-bottom: 4px;
 	transition: border-bottom-color 0.2s ease;
+`;
+
+export const StyledIcon = styled.div`
+	display: none;
+
+	${device.toTablet} {
+		display: flex;
+		align-items: center;
+	}
 `;

--- a/components/Footer/SubFooter/styles.tsx
+++ b/components/Footer/SubFooter/styles.tsx
@@ -16,7 +16,6 @@ export const GridItem = styled.div`
 `;
 
 export const Title = styled.p`
-	font-family: 'Graphik LCG Web', 'sans-serif';
 	font-style: normal;
 	font-weight: 500;
 	font-size: 11px;
@@ -31,7 +30,6 @@ export const Title = styled.p`
 `;
 
 export const Description = styled.div`
-	font-family: 'Graphik LCG Web', 'sans-serif';
 	font-style: normal;
 	font-weight: normal;
 	font-size: 10px;
@@ -63,7 +61,6 @@ export const WrapperItems = styled.div`
 `;
 
 export const LinkItem = styled.a`
-	font-family: 'Graphik LCG Web', 'sans-serif';
 	font-style: normal;
 	font-weight: normal;
 	font-size: 11px;

--- a/components/Footer/__snapshots__/test.spec.tsx.snap
+++ b/components/Footer/__snapshots__/test.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Footer component component matches snapshot 1`] = `
-<styled.div>
+<styled.footer>
   <styled.div>
     <styled.div>
       <styled.div>
@@ -381,5 +381,5 @@ exports[`Footer component component matches snapshot 1`] = `
     <styled.div />
     <SubFooter />
   </styled.div>
-</styled.div>
+</styled.footer>
 `;

--- a/components/Footer/styles.ts
+++ b/components/Footer/styles.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { colours, device } from '../css/tokens';
 
-export const Background = styled.div`
+export const Background = styled.footer`
 	height: 100%;
 	width: 100%;
 	background: ${colours.S1000};
@@ -40,7 +40,7 @@ export const Section = styled.div`
 	width: 100%;
 	background-color: ${colours.S1000};
 
-	${device.toMobileXL} {
-		padding: 64px 24px;
+	${device.toLaptopL} {
+		padding: 64px 40px;
 	}
 `;

--- a/components/Header/LoginDropdown/loginDropdown.styles.ts
+++ b/components/Header/LoginDropdown/loginDropdown.styles.ts
@@ -8,7 +8,6 @@ export const StyledContainer = styled.div`
 	color: ${colours.S1000};
 	display: flex;
 	flex-direction: column;
-	font-family: 'Graphik LCG Web';
 	position: relative;
 	width: 434px;
 	position: absolute;

--- a/components/Header/LoginLink/loginLink.styles.ts
+++ b/components/Header/LoginLink/loginLink.styles.ts
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 export const StyledContainer = styled.div`
 	display: flex;
 	gap: 12px;
-	font-family: 'Graphik LCG Web';
 `;
 
 export const StyledLoginLink = styled.div`

--- a/components/Header/MenuDropdown/menuDropdown.styles.ts
+++ b/components/Header/MenuDropdown/menuDropdown.styles.ts
@@ -7,7 +7,6 @@ export const StyledContainer = styled.div`
 	box-shadow: 0px 2px 5px rgba(12, 17, 66, 0.15);
 	display: flex;
 	flex-direction: column;
-	font-family: 'Graphik LCG Web';
 	position: relative;
 	gap: 16px;
 	padding: 32px;

--- a/components/Header/__snapshots__/test.spec.tsx.snap
+++ b/components/Header/__snapshots__/test.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Header component component matches snapshot 1`] = `
-<styled.div>
+<styled.header>
   <styled.div>
     <styled.a
       href="/"
@@ -20,5 +20,5 @@ exports[`Header component component matches snapshot 1`] = `
     </styled.a>
     <ThemeToggle />
   </styled.div>
-</styled.div>
+</styled.header>
 `;

--- a/components/Header/styles.ts
+++ b/components/Header/styles.ts
@@ -6,12 +6,11 @@ export const StyledLogoIcon = styled(CheckoutLogoIcon)`
 	padding-top: 6px;
 `;
 
-export const StyledContainer = styled.div`
+export const StyledContainer = styled.header`
 	background: white;
 	border-bottom: 1px solid ${colours.S05};
 	display: flex;
 	justify-content: space-between;
-	font-family: 'Graphik LCG Web';
 	padding: 24px 40px;
 	width: 100%;
 `;
@@ -33,13 +32,11 @@ export const StyledLogoText = styled.h3`
 	color: ${colours.S1000};
 	font-size: 24px;
 	line-height: 40px;
-	font-family: 'Graphik LCG Web';
 	margin: 0;
 `;
 
 export const StyledLink = styled.a`
 	color: ${colours.S1000};
-	font-family: Graphik LCG;
 	font-size: 16px;
 	line-height: 24px;
 	letter-spacing: 0em;

--- a/components/Information/component.tsx
+++ b/components/Information/component.tsx
@@ -11,7 +11,6 @@ const StyledWrapper = styled.div`
 	display: grid;
 	grid-template-columns: 60px 1fr;
 	font-size: 16px;
-	font-family: 'Graphik LCG Web';
 	min-height: 90px;
 	position: relative;
 	margin: 40px auto;

--- a/components/Link/component.tsx
+++ b/components/Link/component.tsx
@@ -5,7 +5,6 @@ import { colours } from '../css/tokens';
 const StyledLink = styled.a`
 	color: ${colours.S1000};
 	display: inline-block;
-	font-family: 'Graphik LCG Web';
 	font-size: 16px;
 	font-weight: 500;
 	line-height: 1em;

--- a/components/css/tokens.ts
+++ b/components/css/tokens.ts
@@ -53,7 +53,7 @@ export const size = {
 	mobileXL: '600px',
 	tablet: '768px',
 	laptop: '1024px',
-	laptopL: '1440px',
+	laptopL: '1360px',
 	desktop: '2560px',
 };
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -4,7 +4,7 @@
 require('shelljs/global');
 set('-e');
 
-exec('dotnet build ./openApiGenerator/openApiGenerator.csproj');
-exec('dotnet run -p ./openApiGenerator/openApiGenerator.csproj');
+exec('dotnet build ./openApiGenerator/OpenApiGenerator.csproj');
+exec('dotnet run -p ./openApiGenerator/OpenApiGenerator.csproj');
 
 rm('-rf', 'output');


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/76945510/112474739-e6e75400-8d67-11eb-8a8f-e7f9049e0b2a.png)

- Make footer component match new mobile design
- Set font family on html rather than individual elements
- Use header/footer html elements rather than divs for semantic meaning
- Set link color on header / footer to override redocly styles